### PR TITLE
Dev

### DIFF
--- a/backend/src/controllers/MainGridController.js
+++ b/backend/src/controllers/MainGridController.js
@@ -1,32 +1,13 @@
 const MainGridService = require('../services/MainGridService');
 const mapStatusHttp = require('../utils/mapStatusHttp');
 
-const statusLabels = [
-  'Pendente de confirmação',
-  'Pedido confirmado',
-  'Não reconhece o pedido',
-  'Mercadoria não recebida',
-  'Recebida com avaria',
-  'Devolvida',
-  'Recebida com devolução parcial',
-  'Recebida e confirmada',
-  'Pagamento Autorizado'
-];
-
 const MainGridController = {
   async getAllMainGrid(_req, res) {
     const allDataToMainGrid = await MainGridService.getAllMainGrid();
     if (allDataToMainGrid.status !== "SUCCESSFULL") {
       return res.status(mapStatusHttp(allDataToMainGrid.status)).json(allDataToMainGrid.data);
     }
-
-
-    const mappedData = allDataToMainGrid.data.map(item => ({
-      ...item,
-      status: statusLabels[item.status] ?? item.status
-    }));
-
-    return res.status(200).json(mappedData);
+    return res.status(200).json(allDataToMainGrid.data);
   },
 };
 

--- a/backend/src/services/MainGridService.js
+++ b/backend/src/services/MainGridService.js
@@ -1,9 +1,25 @@
 const MainGridModel = require('../models/MainGridModel');
 
+const statusLabels = [
+    'Pendente de confirmação',
+    'Pedido confirmado',
+    'Não reconhece o pedido',
+    'Mercadoria não recebida',
+    'Recebida com avaria',
+    'Devolvida',
+    'Recebida com devolução parcial',
+    'Recebida e confirmada',
+    'Pagamento Autorizado'
+];
+
 const MainGridService = {
     async getAllMainGrid() {
-            const allDataToMainGrid = await MainGridModel.getAllMainGrid();
-            return { status: "SUCCESSFULL", data: allDataToMainGrid };
+        const allDataToMainGrid = await MainGridModel.getAllMainGrid();
+        const mappedData = allDataToMainGrid.map(item => ({
+            ...item,
+            status: statusLabels[item.status] ?? item.status
+        }));
+        return { status: "SUCCESSFULL", data: mappedData };
     },
 };
 


### PR DESCRIPTION
This pull request refactors the handling of status labels in the `MainGrid` feature by moving the mapping logic from the controller layer to the service layer. This change improves separation of concerns and simplifies the controller code.

### Refactoring for separation of concerns:

* [`backend/src/controllers/MainGridController.js`](diffhunk://#diff-9037237b5cdb3d968f19b02f63f9cf26aab2e4f23e9d4a875609c941e408f181L4-R10): Removed the `statusLabels` array and the logic for mapping status labels from the controller. The controller now directly returns the data provided by the service without additional processing.

* [`backend/src/services/MainGridService.js`](diffhunk://#diff-1afa007de77e2ae687c592f418c53406acff5a10dc32ed364c6e5b1c52b6ffaaR3-R22): Added the `statusLabels` array and moved the status mapping logic into the service layer. The service now processes the data before returning it to the controller, ensuring the mapping is handled closer to the data retrieval logic.